### PR TITLE
Fix zeta services command generation

### DIFF
--- a/zeta/templates/zeta_with_services.template.cmake
+++ b/zeta/templates/zeta_with_services.template.cmake
@@ -10,5 +10,5 @@ execute_process(COMMAND zeta gen -b "$${CMAKE_CURRENT_LIST_DIR}/build"
 list(APPEND HEADERS "$${CMAKE_CURRENT_LIST_DIR}/build/zeta/include/")
 list(APPEND SOURCES ${services_sources})
 
-set(ZEPHYR_MODULES "$${CMAKE_CURRENT_LIST_DIR}/build/zeta")
+set(ZEPHYR_EXTRA_MODULES "$${CMAKE_CURRENT_LIST_DIR}/build/zeta")
 


### PR DESCRIPTION
Signed-off-by: Rodrigo Peixoto <rodrigopex@gmail.com>

The zeta services use other templates than the "zeta.template.cmake" and I did not change that on the last pull request the tests did not capture that. 